### PR TITLE
Res 1203 solve hloc paring and fps-sampling crash when image is less than 10 or 100

### DIFF
--- a/arkit_utils/pose_optimization/optimize_pose.py
+++ b/arkit_utils/pose_optimization/optimize_pose.py
@@ -152,6 +152,9 @@ def setup_hloc(dataset_base: str,
         matches = outputs / 'matches.h5'
 
         logger.info(f"Generating pairs from poses for {method}")
+        # Check number of images and adjust n_matched if needed
+        num_images = len(list(images.iterdir()))
+        n_matched = min(n_matched, num_images)
         pairs_from_poses.main(colmap_arkit, sfm_pairs, n_matched)
 
         if method in ['colmap', 'lightglue', 'glomap']:

--- a/arkit_utils/run_nerfstudio_dataset.py
+++ b/arkit_utils/run_nerfstudio_dataset.py
@@ -25,6 +25,14 @@ def main(args):
     if args.use_icp:
         pose_method = f"{pose_method}_ICP"
 
+    # Check number of images
+    images_dir = output_root / "images"
+    num_images = len(list(images_dir.iterdir())) if images_dir.exists() else 0
+    const_fps_reset = 100
+    sampling_strategy = 'fps'
+    if num_images <= const_fps_reset:
+        sampling_strategy = 'random'
+
     cmds = [
         'ns-train splatfacto ',
         f'--data {output_root} ',
@@ -33,7 +41,7 @@ def main(args):
         '--pipeline.model.rasterize-mode antialiased',
         '--pipeline.model.use-scale-regularization False',
         '--pipeline.model.camera-optimizer.mode SO3xR3',
-        '--pipeline.datamanager.train-cameras-sampling-strategy fps',
+        f'--pipeline.datamanager.train-cameras-sampling-strategy {sampling_strategy}',
         '--pipeline.model.use-bilateral-grid True',
         '--viewer.make-share-url True',
         '--vis viewer+tensorboard',


### PR DESCRIPTION
### Summary:

Hloc paring will crash if the total images is less than 10 (default n_matched value).
Nerfstudio will crash if the total images is less than 100 (default fps-reset-value).

### Details:
1. Check #images images folder, if it's less than 10, than the n_matched will be set to #images.
2. Check #images images folder, if it's less than 100, than the sampling_strategy will set to random, which is default sampling strategy used in Nerfstudio.
