### PR TITLE
Visualize point cloud to check the correctness of camera poses

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,9 +10,8 @@ conda activate homee_nerfstudio
 
 echo "======Phase 2: Installing Nerfstudio dependencies======"
 pip install --upgrade pip
-# pip install torch==2.1.2+cu118 torchvision==0.16.2+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
-pip install torch==2.5.1+cu124 torchvision==0.20.1+cu124 --extra-index-url https://download.pytorch.org/whl/cu124
-conda install -c "nvidia/label/cuda-12.4.0" cuda-toolkit -y
+pip install torch==2.1.2+cu118 torchvision==0.16.2+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
+conda install -c "nvidia/label/cuda-11.8.0" cuda-toolkit -y
 pip install setuptools==69.5.1
 pip install ninja git+https://github.com/NVlabs/tiny-cuda-nn/#subdirectory=bindings/torch
 # may take a while to build tinycudann...

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,8 +10,9 @@ conda activate homee_nerfstudio
 
 echo "======Phase 2: Installing Nerfstudio dependencies======"
 pip install --upgrade pip
-pip install torch==2.1.2+cu118 torchvision==0.16.2+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
-conda install -c "nvidia/label/cuda-11.8.0" cuda-toolkit -y
+# pip install torch==2.1.2+cu118 torchvision==0.16.2+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
+pip install torch==2.5.1+cu124 torchvision==0.20.1+cu124 --extra-index-url https://download.pytorch.org/whl/cu124
+conda install -c "nvidia/label/cuda-12.4.0" cuda-toolkit -y
 pip install setuptools==69.5.1
 pip install ninja git+https://github.com/NVlabs/tiny-cuda-nn/#subdirectory=bindings/torch
 # may take a while to build tinycudann...

--- a/scripts/vis_point_cloud.py
+++ b/scripts/vis_point_cloud.py
@@ -295,26 +295,28 @@ def main():
     for index in tqdm(range(2, 2000)):
         posed_rgbd = reader.get_posed_rgbd(index)
         pcd = posed_rgbd.to_point_cloud()
+        if pcd_all is None:
+            pcd_all = pcd
+        else:
+            pcd_all += pcd
 
-        if args.index >= 0:
+    pcd_all_downsampled = pcd_all.voxel_down_sample(voxel_size=0.05)
+
+    if args.index >= 0:
+        while True:
             # server.scene.add_frame(
             #     f"frame{index}", wxyz=posed_rgbd.q_w2c, position=posed_rgbd.t_w2c
             # )
 
             server.scene.add_point_cloud(
-                f"pcd{index}", np.asarray(pcd.points), np.asarray(pcd.colors)
+                f"pcd{index}",
+                np.asarray(pcd_all_downsampled.points),
+                np.asarray(pcd_all_downsampled.colors),
             )
-        else:
-            if pcd_all is None:
-                pcd_all = pcd
-            else:
-                pcd_all += pcd
-
-    if args.index >= 0:
-        while True:
-            time.sleep(0.033)
     else:
-        assert o3d.io.write_point_cloud("pcd_all.ply", pcd_all, write_ascii=True)
+        assert o3d.io.write_point_cloud(
+            "pcd_all_downsampled.ply", pcd_all_downsampled, write_ascii=True
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/vis_point_cloud.py
+++ b/scripts/vis_point_cloud.py
@@ -1,0 +1,184 @@
+# 3) Read all depth maps and poses
+# 4) Use Knn search to show mutliple point clouds which are color coded
+
+import cv2
+from dataclasses import dataclass
+import open3d as o3d
+from pyquaternion import Quaternion
+import numpy as np
+import viser
+from pathlib import Path
+import matplotlib.pyplot as plt
+
+
+@dataclass
+class PosedRGBDWithCalibration:
+    # Calibration
+    width: int
+    height: int
+    fx: float
+    fy: float
+    cx: float
+    cy: float
+
+    # Pose: tf_w2c
+    t_w2c: np.ndarray
+    q_w2c: np.ndarray
+
+    # RGBD image
+    depth: np.ndarray
+    rgb: np.ndarray
+
+    def __init__(
+        self,
+        w: int,
+        h: int,
+        fx: float,
+        fy: float,
+        cx: float,
+        cy: float,
+        t: np.ndarray,
+        q: np.ndarray,
+        d: np.ndarray,
+        rgb: np.ndarray,
+    ):
+        self.width = w
+        self.height = h
+        self.fx = fx
+        self.fy = fy
+        self.cx = cx
+        self.cy = cy
+        self.t_w2c = t
+        self.q_w2c = q
+        self.depth = d
+        self.rgb = rgb
+
+        assert self.depth.dtype == np.uint16
+        assert self.rgb.dtype == np.uint8
+
+    def to_point_cloud(self):
+        depth_o3d = o3d.geometry.Image(self.depth)
+        rgb_o3d = o3d.geometry.Image(self.rgb)
+        rgbd_o3d = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            rgb_o3d, depth_o3d, convert_rgb_to_intensity=False
+        )
+
+        intrinsic_o3d = o3d.camera.PinholeCameraIntrinsic(
+            self.width, self.height, self.fx, self.fy, self.cx, self.cy
+        )
+
+        tf_w2c = np.eye(4)
+        tf_w2c[:3, :3] = o3d.geometry.get_rotation_matrix_from_quaternion(self.q_w2c)
+        tf_w2c[:3, 3] = self.t_w2c
+
+        # Extrinsic in Open3D is tf_w2c (Open3D internally takes inverse of extrinsic in order to provide a point cloud w.r.t world frame)
+        pcd = o3d.geometry.PointCloud.create_from_rgbd_image(
+            rgbd_o3d, intrinsic_o3d, tf_w2c
+        )
+
+        return pcd
+
+
+def read_depth_map(filename):
+    # Return a depth map in meter
+    with open(filename, "r") as f:
+        # Read dimensions
+        data = f.readlines()
+        rows, cols = map(int, data[0].split())
+
+        # Read depth values (all elements after the first two)
+        depth_values = list(map(float, data[1].split()))
+
+        # Ensure we have the correct number of depth values
+        if len(depth_values) != rows * cols:
+            raise ValueError(
+                f"Expected {rows * cols} depth values, but got {len(depth_values)}"
+            )
+
+        # Reshape to 2D array
+        depth_map = np.array(depth_values).reshape((rows, cols))
+
+    return depth_map
+
+
+def get_scaled_intrinsic(
+    w: int,
+    h: int,
+    fx: float,
+    fy: float,
+    cx: float,
+    cy: float,
+    w_scaled: int,
+    h_scaled: int,
+):
+    fx_scaled = fx * w_scaled / w
+    fy_scaled = fy * h_scaled / h
+    cx_scaled = (cx - w / 2) / w * w_scaled + w_scaled / 2
+    cy_scaled = (cy - h / 2) / h * h_scaled + h_scaled / 2
+
+    return fx_scaled, fy_scaled, cx_scaled, cy_scaled
+
+
+def main():
+    server = viser.ViserServer()
+
+    # Hardcode path here...
+    depth_path = Path(
+        "/home/fuyu/workspace/data/2025-01-26T04_09_44.533Z/3DGS/colmap/depth/0002_depth.txt"
+    )
+    color_path = Path(
+        "/home/fuyu/workspace/data/2025-01-26T04_09_44.533Z/3DGS/colmap/post/images/0002.png"
+    )
+    arkit_poses = Path(
+        "/home/fuyu/workspace/data/2025-01-26T04_09_44.533Z/3DGS/colmap/sparse/0/images.txt"
+    )
+    colmap_poses = Path(
+        "/home/fuyu/workspace/data/2025-01-26T04_09_44.533Z/3DGS/colmap/post/sparse/offline/colmap/final/images.txt"
+    )
+    colmap_icp_poses = Path(
+        "/home/fuyu/workspace/data/2025-01-26T04_09_44.533Z/3DGS/colmap/post/sparse/offline/colmap_ICP/final/images.txt"
+    )
+    k_path = Path(
+        "/home/fuyu/workspace/data/2025-01-26T04_09_44.533Z/3DGS/colmap/sparse/0/distort_cameras.txt"
+    )
+
+    assert depth_path.is_file()
+    assert color_path.is_file()
+    assert arkit_poses.is_file()
+    assert colmap_poses.is_file()
+    assert colmap_icp_poses.is_file()
+    assert k_path.is_file()
+
+    # Read depth map
+    depth = (read_depth_map(depth_path) * 1000).astype(np.uint16)
+
+    # TODO: read intrinsics from k_path
+    depth_fx, depth_fy, depth_cx, depth_cy = get_scaled_intrinsic(
+        1280, 720, 949.321, 949.321, 645.6093, 361.05295, 256, 144
+    )
+
+    # Read color image
+    rgb = cv2.imread(color_path, cv2.IMREAD_UNCHANGED)[:, :, ::-1]
+    rgb = cv2.resize(rgb, (256, 144))
+
+    # TODO: read pose from arkit_poses
+    q_w2c = np.array(
+        [0.018867744, -0.6829312, 0.7199132, 0.122367874]
+    )  # [qw, qx, qy, qz]
+    t_w2c = np.array([-0.21990505, 0.29071486, -0.7248777])  # [tx, ty, tz]
+
+    posed_rgbd = PosedRGBDWithCalibration(
+        256, 144, depth_fx, depth_fy, depth_cx, depth_cy, t_w2c, q_w2c, depth, rgb
+    )
+    pcd = posed_rgbd.to_point_cloud()
+
+    while True:
+        server.scene.add_frame("test")
+
+        server.scene.add_point_cloud(
+            "point cloud", np.asarray(pcd.points), np.asarray(pcd.colors), 0.05
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vis_point_cloud.py
+++ b/scripts/vis_point_cloud.py
@@ -1,5 +1,4 @@
-# 3) Read all depth maps and poses
-# 4) Use Knn search to show mutliple point clouds which are color coded
+# 4) Use Knn search to show multiple point clouds which are color coded
 
 import cv2
 from dataclasses import dataclass
@@ -9,6 +8,10 @@ import numpy as np
 import viser
 from pathlib import Path
 import matplotlib.pyplot as plt
+from nerfstudio.data.utils.colmap_parsing_utils import (
+    read_cameras_text,
+    read_images_text,
+)
 
 
 @dataclass
@@ -72,6 +75,7 @@ class PosedRGBDWithCalibration:
         tf_w2c[:3, 3] = self.t_w2c
 
         # Extrinsic in Open3D is tf_w2c (Open3D internally takes inverse of extrinsic in order to provide a point cloud w.r.t world frame)
+        # TODO: is truncation required for too small depth value or too large depth value?
         pcd = o3d.geometry.PointCloud.create_from_rgbd_image(
             rgbd_o3d, intrinsic_o3d, tf_w2c
         )
@@ -79,55 +83,128 @@ class PosedRGBDWithCalibration:
         return pcd
 
 
-def read_depth_map(filename):
-    # Return a depth map in meter
-    with open(filename, "r") as f:
-        # Read dimensions
-        data = f.readlines()
-        rows, cols = map(int, data[0].split())
+class DatasetReader:
+    def __init__(
+        self, depth_folder: Path, color_folder: Path, calib_file: Path, pose_file
+    ):
+        assert "cameras.txt" in calib_file.name  # colmap format
+        assert pose_file.name == "images.txt"  # colmap format
 
-        # Read depth values (all elements after the first two)
-        depth_values = list(map(float, data[1].split()))
+        self.id_to_depth_path = {
+            int(depth_path.stem[:-6]): depth_path
+            for depth_path in depth_folder.glob("*_depth.txt")
+        }
+        self.id_to_color_path = {
+            int(color_path.stem): color_path
+            for color_path in color_folder.glob("*.png")
+        }
 
-        # Ensure we have the correct number of depth values
-        if len(depth_values) != rows * cols:
-            raise ValueError(
-                f"Expected {rows * cols} depth values, but got {len(depth_values)}"
+        self.id_to_k = read_cameras_text(calib_file)
+        self.id_to_pose = read_images_text(pose_file)
+
+        print(f"Number of depth maps: {len(self.id_to_depth_path)}")
+        print(f"Number of color images: {len(self.id_to_color_path)}")
+        print(f"Number of calibrations: {len(self.id_to_k)}")
+        print(f"Number of poses: {len(self.id_to_pose)}")
+
+    def peek(self, index: int):
+        return (
+            index in self.id_to_depth_path
+            and index in self.id_to_color_path
+            and index in self.id_to_k
+            and index in self.id_to_pose
+        )
+
+    def get_posed_rgbd(self, index: int) -> PosedRGBDWithCalibration:
+        # Convert stored depth value from meter to mm
+        depth = (self.__read_depth_map(self.id_to_depth_path[index]) * 1000).astype(
+            np.uint16
+        )
+
+        rgb = cv2.imread(self.id_to_color_path[index], cv2.IMREAD_UNCHANGED)[:, :, ::-1]
+
+        # Read intrinsic for color image
+        fx, fy, cx, cy = self.id_to_k[index].params
+
+        # compute intrinsic for depth map and resize color image if required.
+        if depth.shape != rgb.shape[:2]:
+            fx, fy, cx, cy = self.__compute_scaled_intrinsic(
+                rgb.shape[1],
+                rgb.shape[0],
+                fx,
+                fy,
+                cx,
+                cy,
+                depth.shape[1],
+                depth.shape[0],
             )
+            rgb = cv2.resize(rgb, (depth.shape[::-1]))
 
-        # Reshape to 2D array
-        depth_map = np.array(depth_values).reshape((rows, cols))
+        return PosedRGBDWithCalibration(
+            depth.shape[1],
+            depth.shape[0],
+            fx,
+            fy,
+            cx,
+            cy,
+            self.id_to_pose[index].tvec,
+            self.id_to_pose[index].qvec,
+            depth,
+            rgb,
+        )
 
-    return depth_map
+    # TODO: move to util
+    def __compute_scaled_intrinsic(
+        self,
+        w: int,
+        h: int,
+        fx: float,
+        fy: float,
+        cx: float,
+        cy: float,
+        w_scaled: int,
+        h_scaled: int,
+    ):
+        fx_scaled = fx * w_scaled / w
+        fy_scaled = fy * h_scaled / h
+        cx_scaled = (cx - w / 2) / w * w_scaled + w_scaled / 2
+        cy_scaled = (cy - h / 2) / h * h_scaled + h_scaled / 2
 
+        return fx_scaled, fy_scaled, cx_scaled, cy_scaled
 
-def get_scaled_intrinsic(
-    w: int,
-    h: int,
-    fx: float,
-    fy: float,
-    cx: float,
-    cy: float,
-    w_scaled: int,
-    h_scaled: int,
-):
-    fx_scaled = fx * w_scaled / w
-    fy_scaled = fy * h_scaled / h
-    cx_scaled = (cx - w / 2) / w * w_scaled + w_scaled / 2
-    cy_scaled = (cy - h / 2) / h * h_scaled + h_scaled / 2
+    # TODO: move to util
+    def __read_depth_map(self, filename):
+        # Return a depth map in meter
+        with open(filename, "r") as f:
+            # Read dimensions
+            data = f.readlines()
+            rows, cols = map(int, data[0].split())
 
-    return fx_scaled, fy_scaled, cx_scaled, cy_scaled
+            # Read depth values (all elements after the first two)
+            depth_values = list(map(float, data[1].split()))
+
+            # Ensure we have the correct number of depth values
+            if len(depth_values) != rows * cols:
+                raise ValueError(
+                    f"Expected {rows * cols} depth values, but got {len(depth_values)}"
+                )
+
+            # Reshape to 2D array
+            depth_map = np.array(depth_values).reshape((rows, cols))
+
+        return depth_map
 
 
 def main():
     server = viser.ViserServer()
 
+    # TODO: use argparse
     # Hardcode path here...
     depth_path = Path(
-        "/home/fuyu/workspace/data/2025-01-26T04_09_44.533Z/3DGS/colmap/depth/0002_depth.txt"
+        "/home/fuyu/workspace/data/2025-01-26T04_09_44.533Z/3DGS/colmap/depth/"
     )
     color_path = Path(
-        "/home/fuyu/workspace/data/2025-01-26T04_09_44.533Z/3DGS/colmap/post/images/0002.png"
+        "/home/fuyu/workspace/data/2025-01-26T04_09_44.533Z/3DGS/colmap/post/images/"
     )
     arkit_poses = Path(
         "/home/fuyu/workspace/data/2025-01-26T04_09_44.533Z/3DGS/colmap/sparse/0/images.txt"
@@ -142,42 +219,28 @@ def main():
         "/home/fuyu/workspace/data/2025-01-26T04_09_44.533Z/3DGS/colmap/sparse/0/distort_cameras.txt"
     )
 
-    assert depth_path.is_file()
-    assert color_path.is_file()
+    assert depth_path.is_dir()
+    assert color_path.is_dir()
     assert arkit_poses.is_file()
     assert colmap_poses.is_file()
     assert colmap_icp_poses.is_file()
     assert k_path.is_file()
 
-    # Read depth map
-    depth = (read_depth_map(depth_path) * 1000).astype(np.uint16)
+    reader = DatasetReader(depth_path, color_path, k_path, arkit_poses)
 
-    # TODO: read intrinsics from k_path
-    depth_fx, depth_fy, depth_cx, depth_cy = get_scaled_intrinsic(
-        1280, 720, 949.321, 949.321, 645.6093, 361.05295, 256, 144
-    )
-
-    # Read color image
-    rgb = cv2.imread(color_path, cv2.IMREAD_UNCHANGED)[:, :, ::-1]
-    rgb = cv2.resize(rgb, (256, 144))
-
-    # TODO: read pose from arkit_poses
-    q_w2c = np.array(
-        [0.018867744, -0.6829312, 0.7199132, 0.122367874]
-    )  # [qw, qx, qy, qz]
-    t_w2c = np.array([-0.21990505, 0.29071486, -0.7248777])  # [tx, ty, tz]
-
-    posed_rgbd = PosedRGBDWithCalibration(
-        256, 144, depth_fx, depth_fy, depth_cx, depth_cy, t_w2c, q_w2c, depth, rgb
-    )
-    pcd = posed_rgbd.to_point_cloud()
-
+    # TODO: not hardcode index range and sliding window size here
     while True:
-        server.scene.add_frame("test")
+        for index in range(2, 10):
+            posed_rgbd = reader.get_posed_rgbd(index)
+            pcd = posed_rgbd.to_point_cloud()
 
-        server.scene.add_point_cloud(
-            "point cloud", np.asarray(pcd.points), np.asarray(pcd.colors), 0.05
-        )
+            server.scene.add_frame(
+                f"frame{index}", wxyz=posed_rgbd.q_w2c, position=posed_rgbd.t_w2c
+            )
+
+            server.scene.add_point_cloud(
+                f"pcd{index}", np.asarray(pcd.points), np.asarray(pcd.colors)
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a script to read data generated in preprocessing step to generate point clouds and visualize them in viser.

Depending on the availability of a frame index, this script can either output all point clouds in a ply file or k nearest point clouds to the given frame. (k is now 10). See two example below.

All point clouds shown in meshlab
<img width="623" alt="image" src="https://github.com/user-attachments/assets/cbb2eb7b-3492-45da-a1c8-821a324f08ee" />

K nearest point clouds.
<img width="980" alt="image" src="https://github.com/user-attachments/assets/210c2d57-8f18-48db-b5d0-17be0af415aa" />

This script has dependency on nerfstudio.data.utils.colmap_parsing_utils so I still  put it in nerfstudio repo